### PR TITLE
Add rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "clean": "tsex clean",
     "compile": "tsex compile",
     "compile:watch": "tsex compile --watch",
+    "bundle": "rollup -c",
     "dev:benchmark": "cd demo/benchmark && npm i && npm update && npm run dev",
     "prod:benchmark": "cd demo/benchmark && npm i && npm update && npm run prod",
     "dev:boxes": "cd demo/boxes && npm i && npm update && npm run dev",
@@ -87,7 +88,10 @@
     "oby": "^15.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
     "@types/node": "^18.15.11",
+    "rollup": "^4.9.6",
     "tsex": "^2.2.4",
     "typescript": "^4.9.5"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+import terser from '@rollup/plugin-terser'
+
+import { defineConfig } from 'rollup'
+export default defineConfig({
+  input: 'dist/index.js',
+  output: [{
+    format: 'module',
+    file: 'dist/index.min.js',
+  }, {
+    format: 'cjs',
+    file: 'dist/index.min.cjs',
+  }],
+  plugins: [nodeResolve(), terser()]
+})


### PR DESCRIPTION
PoC.
Purpose: make bundled voby available on npm.

I didn't know how the build pipeline of this package works so I didn't touch it. I could have also added an iife bundle, but voby doesn't support being set as `window.voby` (I think).

To bundle: `npm compile && npm bundle`

When running the above command, rollup outputs a warning: "circular dependency". Maybe this is concerning?

