### PR TITLE
Move global JSX namespace to separate export

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./jsx": {
+      "import": "./dist/jsx/index.js",
+      "types": "./dist/jsx/index.d.ts"
+    },
     "./jsx-runtime": {
       "import": "./dist/jsx/runtime.js",
       "types": "./dist/jsx/runtime.d.ts"
@@ -89,8 +93,8 @@
     "oby": "^15.1.1"
   },
   "devDependencies": {
-    "@types/node": "^18.19.28",
-    "tsex": "^3.2.1",
+    "@types/node": "^22.5.4",
+    "tsex": "^4.0.2",
     "typescript": "^5.4.3"
   }
 }

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -1,0 +1,129 @@
+
+/* IMPORT */
+
+import type { JSX as JSXInternal } from "./types";
+
+/* GLOBALS */
+
+declare global {
+  namespace JSX {
+    type ArrayMaybe = JSXInternal.ArrayMaybe
+    type FunctionMaybe = JSXInternal.FunctionMaybe
+    type ObservableMaybe = JSXInternal.ObservableMaybe
+    type Nullable = JSXInternal.Nullable
+    type AllClassProperties = JSXInternal.AllClassProperties
+    type DOMCSSProperties = JSXInternal.DOMCSSProperties
+    type DOMCSSVariables = JSXInternal.DOMCSSVariables
+    type HTMLAttributeReferrerPolicy = JSXInternal.HTMLAttributeReferrerPolicy
+    type Child = JSXInternal.Child
+    type Children = JSXInternal.Children
+    type Class = JSXInternal.Class
+    type Component = JSXInternal.Component
+    type Element = JSXInternal.Element
+    type Ref = JSXInternal.Ref
+    type Refs = JSXInternal.Refs
+    type Style = JSXInternal.Style
+    type IntrinsicElement<T extends keyof JSXInternal.IntrinsicElements> = JSXInternal.IntrinsicElement<T>
+    interface ClassProperties extends JSXInternal.ClassProperties { }
+    interface StyleProperties extends JSXInternal.StyleProperties { }
+    type TargetedEvent = JSXInternal.TargetedEvent
+    type TargetedAnimationEvent<T extends EventTarget> = JSXInternal.TargetedAnimationEvent<T>
+    type TargetedClipboardEvent<T extends EventTarget> = JSXInternal.TargetedClipboardEvent<T>
+    type TargetedCompositionEvent<T extends EventTarget> = JSXInternal.TargetedCompositionEvent<T>
+    type TargetedDragEvent<T extends EventTarget> = JSXInternal.TargetedDragEvent<T>
+    type TargetedFocusEvent<T extends EventTarget> = JSXInternal.TargetedFocusEvent<T>
+    type TargetedInputEvent<T extends EventTarget> = JSXInternal.TargetedInputEvent<T>
+    type TargetedKeyboardEvent<T extends EventTarget> = JSXInternal.TargetedKeyboardEvent<T>
+    type TargetedMouseEvent<T extends EventTarget> = JSXInternal.TargetedMouseEvent<T>
+    type TargetedPointerEvent<T extends EventTarget> = JSXInternal.TargetedPointerEvent<T>
+    type TargetedSubmitEvent<T extends EventTarget> = JSXInternal.TargetedSubmitEvent<T>
+    type TargetedTouchEvent<T extends EventTarget> = JSXInternal.TargetedTouchEvent<T>
+    type TargetedTransitionEvent<T extends EventTarget> = JSXInternal.TargetedTransitionEvent<T>
+    type TargetedUIEvent<T extends EventTarget> = JSXInternal.TargetedUIEvent<T>
+    type TargetedWheelEvent<T extends EventTarget> = JSXInternal.TargetedWheelEvent<T>
+    type EventHandler<T extends JSXInternal.TargetedEvent> = JSXInternal.EventHandler<T>
+    type AnimationEventHandler<T extends EventTarget> = JSXInternal.AnimationEventHandler<T>
+    type ClipboardEventHandler<T extends EventTarget> = JSXInternal.ClipboardEventHandler<T>
+    type CompositionEventHandler<T extends EventTarget> = JSXInternal.CompositionEventHandler<T>
+    type DragEventHandler<T extends EventTarget> = JSXInternal.DragEventHandler<T>
+    type FocusEventHandler<T extends EventTarget> = JSXInternal.FocusEventHandler<T>
+    type GenericEventHandler<T extends EventTarget> = JSXInternal.GenericEventHandler<T>
+    type InputEventHandler<T extends EventTarget> = JSXInternal.InputEventHandler<T>
+    type KeyboardEventHandler<T extends EventTarget> = JSXInternal.KeyboardEventHandler<T>
+    type MouseEventHandler<T extends EventTarget> = JSXInternal.MouseEventHandler<T>
+    type PointerEventHandler<T extends EventTarget> = JSXInternal.PointerEventHandler<T>
+    type SubmitEventHandler<T extends EventTarget> = JSXInternal.SubmitEventHandler<T>
+    type TouchEventHandler<T extends EventTarget> = JSXInternal.TouchEventHandler<T>
+    type TransitionEventHandler<T extends EventTarget> = JSXInternal.TransitionEventHandler<T>
+    type UIEventHandler<T extends EventTarget> = JSXInternal.UIEventHandler<T>
+    type WheelEventHandler<T extends EventTarget> = JSXInternal.WheelEventHandler<T>
+    interface ElementAttributesProperty extends JSXInternal.ElementAttributesProperty { }
+    interface ElementChildrenAttribute extends JSXInternal.ElementChildrenAttribute { }
+    interface IntrinsicAttributes extends JSXInternal.IntrinsicAttributes { }
+    interface AriaAttributes extends JSXInternal.AriaAttributes { }
+    interface Directives extends JSXInternal.Directives { }
+    type DirectiveAttributes = JSXInternal.DirectiveAttributes
+    interface EventAttributes<T extends EventTarget> extends JSXInternal.EventAttributes<T> { }
+    interface ViewAttributes extends JSXInternal.ViewAttributes { }
+    interface DOMAttributes<T extends EventTarget> extends JSXInternal.DOMAttributes<T> { }
+    interface VoidHTMLAttributes<T extends EventTarget> extends JSXInternal.VoidHTMLAttributes<T> { }
+    interface HTMLAttributes<T extends EventTarget> extends JSXInternal.HTMLAttributes<T> { }
+    interface SVGAttributes<T extends EventTarget> extends JSXInternal.SVGAttributes<T> { }
+    interface AnchorHTMLAttributes<T extends EventTarget> extends JSXInternal.AnchorHTMLAttributes<T> { }
+    interface AudioHTMLAttributes<T extends EventTarget> extends JSXInternal.AudioHTMLAttributes<T> { }
+    interface AreaHTMLAttributes<T extends EventTarget> extends JSXInternal.AreaHTMLAttributes<T> { }
+    interface BaseHTMLAttributes<T extends EventTarget> extends JSXInternal.BaseHTMLAttributes<T> { }
+    interface BlockquoteHTMLAttributes<T extends EventTarget> extends JSXInternal.BlockquoteHTMLAttributes<T> { }
+    interface BrHTMLAttributes<T extends EventTarget> extends JSXInternal.BrHTMLAttributes<T> { }
+    interface ButtonHTMLAttributes<T extends EventTarget> extends JSXInternal.ButtonHTMLAttributes<T> { }
+    interface CanvasHTMLAttributes<T extends EventTarget> extends JSXInternal.CanvasHTMLAttributes<T> { }
+    interface ColHTMLAttributes<T extends EventTarget> extends JSXInternal.ColHTMLAttributes<T> { }
+    interface ColgroupHTMLAttributes<T extends EventTarget> extends JSXInternal.ColgroupHTMLAttributes<T> { }
+    interface DataHTMLAttributes<T extends EventTarget> extends JSXInternal.DataHTMLAttributes<T> { }
+    interface DetailsHTMLAttributes<T extends EventTarget> extends JSXInternal.DetailsHTMLAttributes<T> { }
+    interface DelHTMLAttributes<T extends EventTarget> extends JSXInternal.DelHTMLAttributes<T> { }
+    interface DialogHTMLAttributes<T extends EventTarget> extends JSXInternal.DialogHTMLAttributes<T> { }
+    interface EmbedHTMLAttributes<T extends EventTarget> extends JSXInternal.EmbedHTMLAttributes<T> { }
+    interface FieldsetHTMLAttributes<T extends EventTarget> extends JSXInternal.FieldsetHTMLAttributes<T> { }
+    interface FormHTMLAttributes<T extends EventTarget> extends JSXInternal.FormHTMLAttributes<T> { }
+    interface HrHTMLAttributes<T extends EventTarget> extends JSXInternal.HrHTMLAttributes<T> { }
+    interface HtmlHTMLAttributes<T extends EventTarget> extends JSXInternal.HtmlHTMLAttributes<T> { }
+    interface IframeHTMLAttributes<T extends EventTarget> extends JSXInternal.IframeHTMLAttributes<T> { }
+    interface ImgHTMLAttributes<T extends EventTarget> extends JSXInternal.ImgHTMLAttributes<T> { }
+    interface InsHTMLAttributes<T extends EventTarget> extends JSXInternal.InsHTMLAttributes<T> { }
+    interface InputHTMLAttributes<T extends EventTarget> extends JSXInternal.InputHTMLAttributes<T> { }
+    interface KeygenHTMLAttributes<T extends EventTarget> extends JSXInternal.KeygenHTMLAttributes<T> { }
+    interface LabelHTMLAttributes<T extends EventTarget> extends JSXInternal.LabelHTMLAttributes<T> { }
+    interface LiHTMLAttributes<T extends EventTarget> extends JSXInternal.LiHTMLAttributes<T> { }
+    interface LinkHTMLAttributes<T extends EventTarget> extends JSXInternal.LinkHTMLAttributes<T> { }
+    interface MapHTMLAttributes<T extends EventTarget> extends JSXInternal.MapHTMLAttributes<T> { }
+    interface MenuHTMLAttributes<T extends EventTarget> extends JSXInternal.MenuHTMLAttributes<T> { }
+    interface MediaHTMLAttributes<T extends EventTarget> extends JSXInternal.MediaHTMLAttributes<T> { }
+    interface MetaHTMLAttributes<T extends EventTarget> extends JSXInternal.MetaHTMLAttributes<T> { }
+    interface MeterHTMLAttributes<T extends EventTarget> extends JSXInternal.MeterHTMLAttributes<T> { }
+    interface QuoteHTMLAttributes<T extends EventTarget> extends JSXInternal.QuoteHTMLAttributes<T> { }
+    interface ObjectHTMLAttributes<T extends EventTarget> extends JSXInternal.ObjectHTMLAttributes<T> { }
+    interface OlHTMLAttributes<T extends EventTarget> extends JSXInternal.OlHTMLAttributes<T> { }
+    interface OptgroupHTMLAttributes<T extends EventTarget> extends JSXInternal.OptgroupHTMLAttributes<T> { }
+    interface OptionHTMLAttributes<T extends EventTarget> extends JSXInternal.OptionHTMLAttributes<T> { }
+    interface OutputHTMLAttributes<T extends EventTarget> extends JSXInternal.OutputHTMLAttributes<T> { }
+    interface ParamHTMLAttributes<T extends EventTarget> extends JSXInternal.ParamHTMLAttributes<T> { }
+    interface ProgressHTMLAttributes<T extends EventTarget> extends JSXInternal.ProgressHTMLAttributes<T> { }
+    interface SlotHTMLAttributes<T extends EventTarget> extends JSXInternal.SlotHTMLAttributes<T> { }
+    interface ScriptHTMLAttributes<T extends EventTarget> extends JSXInternal.ScriptHTMLAttributes<T> { }
+    interface SelectHTMLAttributes<T extends EventTarget> extends JSXInternal.SelectHTMLAttributes<T> { }
+    interface SourceHTMLAttributes<T extends EventTarget> extends JSXInternal.SourceHTMLAttributes<T> { }
+    interface StyleHTMLAttributes<T extends EventTarget> extends JSXInternal.StyleHTMLAttributes<T> { }
+    interface TableHTMLAttributes<T extends EventTarget> extends JSXInternal.TableHTMLAttributes<T> { }
+    interface TextareaHTMLAttributes<T extends EventTarget> extends JSXInternal.TextareaHTMLAttributes<T> { }
+    interface TdHTMLAttributes<T extends EventTarget> extends JSXInternal.TdHTMLAttributes<T> { }
+    interface ThHTMLAttributes<T extends EventTarget> extends JSXInternal.ThHTMLAttributes<T> { }
+    interface TimeHTMLAttributes<T extends EventTarget> extends JSXInternal.TimeHTMLAttributes<T> { }
+    interface TrackHTMLAttributes<T extends EventTarget> extends JSXInternal.TrackHTMLAttributes<T> { }
+    interface VideoHTMLAttributes<T extends EventTarget> extends JSXInternal.VideoHTMLAttributes<T> { }
+    interface WbrHTMLAttributes<T extends EventTarget> extends JSXInternal.WbrHTMLAttributes<T> { }
+    interface WebViewHTMLAttributes<T extends EventTarget> extends JSXInternal.WebViewHTMLAttributes<T> { }
+    interface IntrinsicElementsMap extends JSXInternal.IntrinsicElementsMap { }
+    interface IntrinsicElements extends JSXInternal.IntrinsicElements { }
+  }
+}

--- a/src/jsx/runtime.ts
+++ b/src/jsx/runtime.ts
@@ -1,7 +1,6 @@
 
 /* IMPORT */
 
-import './types';
 import Fragment from '~/components/fragment';
 import createElement from '~/methods/create_element';
 import type {Component, Element} from '~/types';
@@ -18,4 +17,5 @@ const jsx = <P extends {} = {}> ( component: Component<P>, props?: P | null, key
 
 /* EXPORT */
 
+export * from './types';
 export {jsx, jsx as jsxs, jsx as jsxDEV, Fragment};

--- a/src/jsx/types.ts
+++ b/src/jsx/types.ts
@@ -3,117 +3,118 @@
 
 /* GLOBALS */
 
+// @ts-ignore unused
 interface Element {
   cloneNode ( deep?: boolean ): Element
 }
 
-interface HTMLElement {
+interface HTMLElement extends EventTarget {
   cloneNode ( deep?: boolean ): HTMLElement
 }
 
-interface SVGElement {
+interface SVGElement extends EventTarget {
   cloneNode ( deep?: boolean ): SVGElement
 }
 
 /* JSX */
 
-declare namespace JSX {
+export namespace JSX {
 
   /* HELPERS */
 
-  type ArrayMaybe<T = unknown> = T[] | T;
+  export type ArrayMaybe<T = unknown> = T[] | T;
 
-  type FunctionMaybe<T = unknown> = ({ (): T }) | T;
+  export type FunctionMaybe<T = unknown> = ({ (): T }) | T;
 
-  type ObservableMaybe<T = unknown> = ({ (): T }) | T;
+  export type ObservableMaybe<T = unknown> = ({ (): T }) | T;
 
-  type Nullable<T = unknown> = T | undefined | null;
+  export type Nullable<T = unknown> = T | undefined | null;
 
-  type AllClassProperties = {
+  export type AllClassProperties = {
     [key: string]: FunctionMaybe<Nullable<boolean>>
   };
 
-  type DOMCSSProperties = {
+  export type DOMCSSProperties = {
     [key in keyof Omit<CSSStyleDeclaration, 'item' | 'setProperty' | 'removeProperty' | 'getPropertyValue' | 'getPropertyPriority'>]?: FunctionMaybe<Nullable<string | number>>
   };
 
-  type DOMCSSVariables = {
+  export type DOMCSSVariables = {
     [key: `--${string}`]: FunctionMaybe<Nullable<string | number>>
   };
 
-  type HTMLAttributeReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';
+  export type HTMLAttributeReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';
 
   /* MAIN */
 
-  type Child = null | undefined | boolean | bigint | number | string | symbol | Node | Array<Child> | (() => Child);
+  export type Child = null | undefined | boolean | bigint | number | string | symbol | Node | Array<Child> | (() => Child);
 
-  type Children = Child;
+  export type Children = Child;
 
-  type Class = FunctionMaybe<Nullable<string | ClassProperties | (FunctionMaybe<null | undefined | boolean | string> | Class)[]>>;
+  export type Class = FunctionMaybe<Nullable<string | ClassProperties | (FunctionMaybe<null | undefined | boolean | string> | Class)[]>>;
 
-  type Component<P = {}> = ( props: P ) => Child;
+  export type Component<P = {}> = ( props: P ) => Child;
 
-  type Element = Child;
+  export type Element = Child;
 
-  type Ref<T = unknown> = (( value: T ) => void);
+  export type Ref<T = unknown> = (( value: T ) => void);
 
-  type Refs<T = unknown> = ArrayMaybe<Nullable<Ref<T>>> | Refs<T>[];
+  export type Refs<T = unknown> = ArrayMaybe<Nullable<Ref<T>>> | Refs<T>[];
 
-  type Style = FunctionMaybe<Nullable<string | StyleProperties | (FunctionMaybe<null | undefined | number | string> | Style)[]>>;
+  export type Style = FunctionMaybe<Nullable<string | StyleProperties | (FunctionMaybe<null | undefined | number | string> | Style)[]>>;
 
-  type IntrinsicElement<T extends keyof IntrinsicElements> = IntrinsicElements[T];
+  export type IntrinsicElement<T extends keyof IntrinsicElements> = IntrinsicElements[T];
 
-  interface ClassProperties extends AllClassProperties {}
+  export interface ClassProperties extends AllClassProperties {}
 
-  interface StyleProperties extends DOMCSSProperties, DOMCSSVariables {
+  export interface StyleProperties extends DOMCSSProperties, DOMCSSVariables {
     zoom?: FunctionMaybe<Nullable<string | number>>
   }
 
-  type TargetedEvent<T extends EventTarget = EventTarget, TypedEvent extends Event = Event> = Omit<TypedEvent, 'currentTarget'> & { readonly currentTarget: T };
-  type TargetedAnimationEvent<T extends EventTarget> = TargetedEvent<T, AnimationEvent>;
-  type TargetedClipboardEvent<T extends EventTarget> = TargetedEvent<T, ClipboardEvent>;
-  type TargetedCompositionEvent<T extends EventTarget> = TargetedEvent<T, CompositionEvent>;
-  type TargetedDragEvent<T extends EventTarget> = TargetedEvent<T, DragEvent>;
-  type TargetedFocusEvent<T extends EventTarget> = TargetedEvent<T, FocusEvent>;
-  type TargetedInputEvent<T extends EventTarget> = TargetedEvent<T, InputEvent>;
-  type TargetedKeyboardEvent<T extends EventTarget> = TargetedEvent<T, KeyboardEvent>;
-  type TargetedMouseEvent<T extends EventTarget> = TargetedEvent<T, MouseEvent>;
-  type TargetedPointerEvent<T extends EventTarget> = TargetedEvent<T, PointerEvent>;
-  type TargetedSubmitEvent<T extends EventTarget> = TargetedEvent<T, SubmitEvent>;
-  type TargetedTouchEvent<T extends EventTarget> = TargetedEvent<T, TouchEvent>;
-  type TargetedTransitionEvent<T extends EventTarget> = TargetedEvent<T, TransitionEvent>;
-  type TargetedUIEvent<T extends EventTarget> = TargetedEvent<T, UIEvent>;
-  type TargetedWheelEvent<T extends EventTarget> = TargetedEvent<T, WheelEvent>;
+  export type TargetedEvent<T extends EventTarget = EventTarget, TypedEvent extends Event = Event> = Omit<TypedEvent, 'currentTarget'> & { readonly currentTarget: T };
+  export type TargetedAnimationEvent<T extends EventTarget> = TargetedEvent<T, AnimationEvent>;
+  export type TargetedClipboardEvent<T extends EventTarget> = TargetedEvent<T, ClipboardEvent>;
+  export type TargetedCompositionEvent<T extends EventTarget> = TargetedEvent<T, CompositionEvent>;
+  export type TargetedDragEvent<T extends EventTarget> = TargetedEvent<T, DragEvent>;
+  export type TargetedFocusEvent<T extends EventTarget> = TargetedEvent<T, FocusEvent>;
+  export type TargetedInputEvent<T extends EventTarget> = TargetedEvent<T, InputEvent>;
+  export type TargetedKeyboardEvent<T extends EventTarget> = TargetedEvent<T, KeyboardEvent>;
+  export type TargetedMouseEvent<T extends EventTarget> = TargetedEvent<T, MouseEvent>;
+  export type TargetedPointerEvent<T extends EventTarget> = TargetedEvent<T, PointerEvent>;
+  export type TargetedSubmitEvent<T extends EventTarget> = TargetedEvent<T, SubmitEvent>;
+  export type TargetedTouchEvent<T extends EventTarget> = TargetedEvent<T, TouchEvent>;
+  export type TargetedTransitionEvent<T extends EventTarget> = TargetedEvent<T, TransitionEvent>;
+  export type TargetedUIEvent<T extends EventTarget> = TargetedEvent<T, UIEvent>;
+  export type TargetedWheelEvent<T extends EventTarget> = TargetedEvent<T, WheelEvent>;
 
-  type EventHandler<Event extends TargetedEvent> = { ( this: never, event: Event ): void };
-  type AnimationEventHandler<T extends EventTarget> = EventHandler<TargetedAnimationEvent<T>>;
-  type ClipboardEventHandler<T extends EventTarget> = EventHandler<TargetedClipboardEvent<T>>;
-  type CompositionEventHandler<T extends EventTarget> = EventHandler<TargetedCompositionEvent<T>>;
-  type DragEventHandler<T extends EventTarget> = EventHandler<TargetedDragEvent<T>>;
-  type FocusEventHandler<T extends EventTarget> = EventHandler<TargetedFocusEvent<T>>;
-  type GenericEventHandler<T extends EventTarget> = EventHandler<TargetedEvent<T>>;
-  type InputEventHandler<T extends EventTarget> = EventHandler<TargetedInputEvent<T>>;
-  type KeyboardEventHandler<T extends EventTarget> = EventHandler<TargetedKeyboardEvent<T>>;
-  type MouseEventHandler<T extends EventTarget> = EventHandler<TargetedMouseEvent<T>>;
-  type PointerEventHandler<T extends EventTarget> = EventHandler<TargetedPointerEvent<T>>;
-  type SubmitEventHandler<T extends EventTarget> = EventHandler<TargetedSubmitEvent<T>>;
-  type TouchEventHandler<T extends EventTarget> = EventHandler<TargetedTouchEvent<T>>;
-  type TransitionEventHandler<T extends EventTarget> = EventHandler<TargetedTransitionEvent<T>>;
-  type UIEventHandler<T extends EventTarget> = EventHandler<TargetedUIEvent<T>>;
-  type WheelEventHandler<T extends EventTarget> = EventHandler<TargetedWheelEvent<T>>;
+  export type EventHandler<Event extends TargetedEvent> = { ( this: never, event: Event ): void };
+  export type AnimationEventHandler<T extends EventTarget> = EventHandler<TargetedAnimationEvent<T>>;
+  export type ClipboardEventHandler<T extends EventTarget> = EventHandler<TargetedClipboardEvent<T>>;
+  export type CompositionEventHandler<T extends EventTarget> = EventHandler<TargetedCompositionEvent<T>>;
+  export type DragEventHandler<T extends EventTarget> = EventHandler<TargetedDragEvent<T>>;
+  export type FocusEventHandler<T extends EventTarget> = EventHandler<TargetedFocusEvent<T>>;
+  export type GenericEventHandler<T extends EventTarget> = EventHandler<TargetedEvent<T>>;
+  export type InputEventHandler<T extends EventTarget> = EventHandler<TargetedInputEvent<T>>;
+  export type KeyboardEventHandler<T extends EventTarget> = EventHandler<TargetedKeyboardEvent<T>>;
+  export type MouseEventHandler<T extends EventTarget> = EventHandler<TargetedMouseEvent<T>>;
+  export type PointerEventHandler<T extends EventTarget> = EventHandler<TargetedPointerEvent<T>>;
+  export type SubmitEventHandler<T extends EventTarget> = EventHandler<TargetedSubmitEvent<T>>;
+  export type TouchEventHandler<T extends EventTarget> = EventHandler<TargetedTouchEvent<T>>;
+  export type TransitionEventHandler<T extends EventTarget> = EventHandler<TargetedTransitionEvent<T>>;
+  export type UIEventHandler<T extends EventTarget> = EventHandler<TargetedUIEvent<T>>;
+  export type WheelEventHandler<T extends EventTarget> = EventHandler<TargetedWheelEvent<T>>;
 
-  interface ElementAttributesProperty {
+  export interface ElementAttributesProperty {
     props: Record<string, any>
   }
 
-  interface ElementChildrenAttribute {
+  export interface ElementChildrenAttribute {
     children: any
   }
 
-  interface IntrinsicAttributes {
+  export interface IntrinsicAttributes {
   }
 
-  interface AriaAttributes {
+  export interface AriaAttributes {
     ariaActiveDescendant?: FunctionMaybe<Nullable<string>>,
     ariaAtomic?: FunctionMaybe<Nullable<boolean | 'true' | 'false'>>,
     ariaAutoComplete?: FunctionMaybe<Nullable<'none' | 'inline' | 'list' | 'both'>>,
@@ -167,18 +168,18 @@ declare namespace JSX {
     ariaValueText?: FunctionMaybe<Nullable<string>>
   }
 
-  interface Directives {
+  export interface Directives {
     //FIXME: remove these internal directives https://github.com/microsoft/TypeScript/issues/49536
     __voby_internal1__: [],
     __voby_internal2__: [],
     // name: [arg1: unknown, arg2: unknown, ...argN: unknown]
   }
 
-  type DirectiveAttributes = {
+  export type DirectiveAttributes = {
     [Directive in keyof Directives as `use:${Directive}`]?: Directives[Directive] extends [infer U] ? U | [U] : Directives[Directive];
   };
 
-  interface EventAttributes<T extends EventTarget> {
+  export interface EventAttributes<T extends EventTarget> {
     /* IMAGE EVENTS */
     onLoad?: ObservableMaybe<Nullable<GenericEventHandler<T>>>,
     onLoadCapture?: ObservableMaybe<Nullable<GenericEventHandler<T>>>,
@@ -376,18 +377,18 @@ declare namespace JSX {
     onTransitionEndCapture?: ObservableMaybe<Nullable<TransitionEventHandler<T>>>
   }
 
-  interface ViewAttributes {
+  export interface ViewAttributes {
     children?: Children,
     dangerouslySetInnerHTML?: FunctionMaybe<{
       __html: FunctionMaybe<Nullable<string>>
     }>
   }
 
-  interface DOMAttributes<T extends EventTarget> extends EventAttributes<T> {
+  export interface DOMAttributes<T extends EventTarget> extends EventAttributes<T> {
 
   }
 
-  interface VoidHTMLAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T>, DirectiveAttributes {
+  export interface VoidHTMLAttributes<T extends EventTarget> extends AriaAttributes, DOMAttributes<T>, DirectiveAttributes {
     ref?: Refs<T>,
 
     accept?: FunctionMaybe<Nullable<string>>,
@@ -562,11 +563,11 @@ declare namespace JSX {
     itemRef?: FunctionMaybe<Nullable<string>>
   }
 
-  interface HTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T>, ViewAttributes {
+  export interface HTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T>, ViewAttributes {
 
   }
 
-  interface SVGAttributes<T extends EventTarget = SVGElement> extends HTMLAttributes<T>, DirectiveAttributes {
+  export interface SVGAttributes<T extends EventTarget = SVGElement> extends HTMLAttributes<T>, DirectiveAttributes {
     ref?: Refs<T>,
 
     accentHeight?: FunctionMaybe<Nullable<number | string>>,
@@ -814,7 +815,7 @@ declare namespace JSX {
     'xmlns:xlink'?: FunctionMaybe<Nullable<string>>,
   }
 
-  interface AnchorHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface AnchorHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     download?: FunctionMaybe<Nullable<boolean>>,
     href?: FunctionMaybe<Nullable<string>>,
     hrefLang?: FunctionMaybe<Nullable<string>>,
@@ -826,11 +827,11 @@ declare namespace JSX {
     referrerPolicy?: FunctionMaybe<Nullable<HTMLAttributeReferrerPolicy>>
   }
 
-  interface AudioHTMLAttributes<T extends EventTarget> extends MediaHTMLAttributes<T> {
+  export interface AudioHTMLAttributes<T extends EventTarget> extends MediaHTMLAttributes<T> {
 
   }
 
-  interface AreaHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface AreaHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     alt?: FunctionMaybe<Nullable<string>>,
     coords?: FunctionMaybe<Nullable<string>>,
     download?: FunctionMaybe<Nullable<boolean>>,
@@ -843,20 +844,20 @@ declare namespace JSX {
     target?: FunctionMaybe<Nullable<string>>
   }
 
-  interface BaseHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface BaseHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     href?: FunctionMaybe<Nullable<string>>,
     target?: FunctionMaybe<Nullable<string>>
   }
 
-  interface BlockquoteHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface BlockquoteHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     cite?: FunctionMaybe<Nullable<string>>
   }
 
-  interface BrHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface BrHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
 
   }
 
-  interface ButtonHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface ButtonHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     autoFocus?: FunctionMaybe<Nullable<boolean>>,
     disabled?: FunctionMaybe<Nullable<boolean>>,
     form?: FunctionMaybe<Nullable<string>>,
@@ -870,52 +871,52 @@ declare namespace JSX {
     value?: FunctionMaybe<Nullable<string | ReadonlyArray<string> | number>>
   }
 
-  interface CanvasHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface CanvasHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     height?: FunctionMaybe<Nullable<number | string>>,
     width?: FunctionMaybe<Nullable<number | string>>
   }
 
-  interface ColHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface ColHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     span?: FunctionMaybe<Nullable<number>>,
     width?: FunctionMaybe<Nullable<number | string>>
   }
 
-  interface ColgroupHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface ColgroupHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     span?: FunctionMaybe<Nullable<number>>
   }
 
-  interface DataHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface DataHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     value?: FunctionMaybe<Nullable<string | ReadonlyArray<string> | number>>
   }
 
-  interface DetailsHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface DetailsHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     open?: FunctionMaybe<Nullable<boolean>>,
     onToggle?: ObservableMaybe<Nullable<GenericEventHandler<T>>>
   }
 
-  interface DelHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface DelHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     cite?: FunctionMaybe<Nullable<string>>,
     dateTime?: FunctionMaybe<Nullable<string>>
   }
 
-  interface DialogHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface DialogHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     open?: FunctionMaybe<Nullable<boolean>>
   }
 
-  interface EmbedHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface EmbedHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     height?: FunctionMaybe<Nullable<number | string>>,
     src?: FunctionMaybe<Nullable<string>>,
     type?: FunctionMaybe<Nullable<string>>,
     width?: FunctionMaybe<Nullable<number | string>>
   }
 
-  interface FieldsetHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface FieldsetHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     disabled?: FunctionMaybe<Nullable<boolean>>,
     form?: FunctionMaybe<Nullable<string>>,
     name?: FunctionMaybe<Nullable<string>>
   }
 
-  interface FormHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface FormHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     acceptCharset?: FunctionMaybe<Nullable<string>>,
     action?: FunctionMaybe<Nullable<string>>,
     autoComplete?: FunctionMaybe<Nullable<string>>,
@@ -926,15 +927,15 @@ declare namespace JSX {
     target?: FunctionMaybe<Nullable<string>>
   }
 
-  interface HrHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface HrHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
 
   }
 
-  interface HtmlHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface HtmlHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     manifest?: FunctionMaybe<Nullable<string>>
   }
 
-  interface IframeHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface IframeHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     allow?: FunctionMaybe<Nullable<string>>,
     allowFullScreen?: FunctionMaybe<Nullable<boolean>>,
     allowTransparency?: FunctionMaybe<Nullable<boolean>>,
@@ -957,7 +958,7 @@ declare namespace JSX {
     width?: FunctionMaybe<Nullable<number | string>>
   }
 
-  interface ImgHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface ImgHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     alt?: FunctionMaybe<Nullable<string>>,
     crossOrigin?: FunctionMaybe<Nullable<'anonymous' | 'use-credentials' | ''>>,
     decoding?: FunctionMaybe<Nullable<'async' | 'auto' | 'sync'>>,
@@ -971,12 +972,12 @@ declare namespace JSX {
     width?: FunctionMaybe<Nullable<number | string>>
   }
 
-  interface InsHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface InsHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     cite?: FunctionMaybe<Nullable<string>>,
     dateTime?: FunctionMaybe<Nullable<string>>
   }
 
-  interface InputHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface InputHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     accept?: FunctionMaybe<Nullable<string>>,
     alt?: FunctionMaybe<Nullable<string>>,
     autoComplete?: FunctionMaybe<Nullable<string>>,
@@ -1014,7 +1015,7 @@ declare namespace JSX {
     onChange?: ObservableMaybe<Nullable<KeyboardEventHandler<T>>>
   }
 
-  interface KeygenHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface KeygenHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     autoFocus?: FunctionMaybe<Nullable<boolean>>,
     challenge?: FunctionMaybe<Nullable<string>>,
     disabled?: FunctionMaybe<Nullable<boolean>>,
@@ -1024,17 +1025,17 @@ declare namespace JSX {
     name?: FunctionMaybe<Nullable<string>>
   }
 
-  interface LabelHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface LabelHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     form?: FunctionMaybe<Nullable<string>>,
     htmlFor?: FunctionMaybe<Nullable<string>>,
     for?: FunctionMaybe<Nullable<string>>
   }
 
-  interface LiHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface LiHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     value?: FunctionMaybe<Nullable<string | ReadonlyArray<string> | number>>
   }
 
-  interface LinkHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface LinkHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     as?: FunctionMaybe<Nullable<string>>,
     crossOrigin?: FunctionMaybe<Nullable<string>>,
     href?: FunctionMaybe<Nullable<string>>,
@@ -1049,15 +1050,15 @@ declare namespace JSX {
     charSet?: FunctionMaybe<Nullable<string>>
   }
 
-  interface MapHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface MapHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     name?: FunctionMaybe<Nullable<string>>
   }
 
-  interface MenuHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface MenuHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     type?: FunctionMaybe<Nullable<string>>
   }
 
-  interface MediaHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface MediaHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     autoPlay?: FunctionMaybe<Nullable<boolean>>,
     controls?: FunctionMaybe<Nullable<boolean>>,
     controlsList?: FunctionMaybe<Nullable<string>>,
@@ -1070,7 +1071,7 @@ declare namespace JSX {
     src?: FunctionMaybe<Nullable<string>>
   }
 
-  interface MetaHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface MetaHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     charSet?: FunctionMaybe<Nullable<string>>,
     content?: FunctionMaybe<Nullable<string>>,
     httpEquiv?: FunctionMaybe<Nullable<string>>,
@@ -1078,7 +1079,7 @@ declare namespace JSX {
     media?: FunctionMaybe<Nullable<string>>
   }
 
-  interface MeterHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface MeterHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     form?: FunctionMaybe<Nullable<string>>,
     high?: FunctionMaybe<Nullable<number>>,
     low?: FunctionMaybe<Nullable<number>>,
@@ -1088,11 +1089,11 @@ declare namespace JSX {
     value?: FunctionMaybe<Nullable<string | ReadonlyArray<string> | number>>
   }
 
-  interface QuoteHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface QuoteHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     cite?: FunctionMaybe<Nullable<string>>
   }
 
-  interface ObjectHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface ObjectHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     classID?: FunctionMaybe<Nullable<string>>,
     data?: FunctionMaybe<Nullable<string>>,
     form?: FunctionMaybe<Nullable<string>>,
@@ -1104,46 +1105,46 @@ declare namespace JSX {
     wmode?: FunctionMaybe<Nullable<string>>
   }
 
-  interface OlHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface OlHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     reversed?: FunctionMaybe<Nullable<boolean>>,
     start?: FunctionMaybe<Nullable<number>>,
     type?: FunctionMaybe<Nullable<'1' | 'a' | 'A' | 'i' | 'I'>>
   }
 
-  interface OptgroupHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface OptgroupHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     disabled?: FunctionMaybe<Nullable<boolean>>,
     label?: FunctionMaybe<Nullable<string>>
   }
 
-  interface OptionHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface OptionHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     disabled?: FunctionMaybe<Nullable<boolean>>,
     label?: FunctionMaybe<Nullable<string>>,
     selected?: FunctionMaybe<Nullable<boolean>>,
     value?: FunctionMaybe<Nullable<string | ReadonlyArray<string> | number>>
   }
 
-  interface OutputHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface OutputHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     form?: FunctionMaybe<Nullable<string>>,
     htmlFor?: FunctionMaybe<Nullable<string>>,
     for?: FunctionMaybe<Nullable<string>>,
     name?: FunctionMaybe<Nullable<string>>
   }
 
-  interface ParamHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface ParamHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     name?: FunctionMaybe<Nullable<string>>,
     value?: FunctionMaybe<Nullable<string | ReadonlyArray<string> | number>>
   }
 
-  interface ProgressHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface ProgressHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     max?: FunctionMaybe<Nullable<number | string>>,
     value?: FunctionMaybe<Nullable<string | ReadonlyArray<string> | number>>,
   }
 
-  interface SlotHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface SlotHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     name?: FunctionMaybe<Nullable<string>>
   }
 
-  interface ScriptHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface ScriptHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     async?: FunctionMaybe<Nullable<boolean>>,
     /** @deprecated */
     charSet?: FunctionMaybe<Nullable<string>>,
@@ -1157,7 +1158,7 @@ declare namespace JSX {
     type?: FunctionMaybe<Nullable<string>>
   }
 
-  interface SelectHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface SelectHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     autoComplete?: FunctionMaybe<Nullable<string>>,
     autoFocus?: FunctionMaybe<Nullable<boolean>>,
     disabled?: FunctionMaybe<Nullable<boolean>>,
@@ -1170,7 +1171,7 @@ declare namespace JSX {
     onChange?: ObservableMaybe<Nullable<KeyboardEventHandler<T>>>
   }
 
-  interface SourceHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface SourceHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     height?: FunctionMaybe<Nullable<number | string>>,
     media?: FunctionMaybe<Nullable<string>>,
     sizes?: FunctionMaybe<Nullable<string>>,
@@ -1180,21 +1181,21 @@ declare namespace JSX {
     width?: FunctionMaybe<Nullable<number | string>>
   }
 
-  interface StyleHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface StyleHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     media?: FunctionMaybe<Nullable<string>>,
     nonce?: FunctionMaybe<Nullable<string>>,
     scoped?: FunctionMaybe<Nullable<boolean>>,
     type?: FunctionMaybe<Nullable<string>>
   }
 
-  interface TableHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface TableHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     cellPadding?: FunctionMaybe<Nullable<number | string>>,
     cellSpacing?: FunctionMaybe<Nullable<number | string>>,
     summary?: FunctionMaybe<Nullable<string>>,
     width?: FunctionMaybe<Nullable<number | string>>
   }
 
-  interface TextareaHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface TextareaHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     autoComplete?: FunctionMaybe<Nullable<string>>,
     autoFocus?: FunctionMaybe<Nullable<boolean>>,
     cols?: FunctionMaybe<Nullable<number>>,
@@ -1213,7 +1214,7 @@ declare namespace JSX {
     onChange?: ObservableMaybe<Nullable<KeyboardEventHandler<T>>>
   }
 
-  interface TdHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface TdHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     align?: FunctionMaybe<Nullable<'left' | 'center' | 'right' | 'justify' | 'char'>>,
     colSpan?: FunctionMaybe<Nullable<number>>,
     headers?: FunctionMaybe<Nullable<string>>,
@@ -1225,7 +1226,7 @@ declare namespace JSX {
     valign?: FunctionMaybe<Nullable<'top' | 'middle' | 'bottom' | 'baseline'>>
   }
 
-  interface ThHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface ThHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     align?: FunctionMaybe<Nullable<'left' | 'center' | 'right' | 'justify' | 'char'>>,
     colSpan?: FunctionMaybe<Nullable<number>>,
     headers?: FunctionMaybe<Nullable<string>>,
@@ -1234,11 +1235,11 @@ declare namespace JSX {
     abbr?: FunctionMaybe<Nullable<string>>
   }
 
-  interface TimeHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface TimeHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     dateTime?: FunctionMaybe<Nullable<string>>
   }
 
-  interface TrackHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface TrackHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
     default?: FunctionMaybe<Nullable<boolean>>,
     kind?: FunctionMaybe<Nullable<string>>,
     label?: FunctionMaybe<Nullable<string>>,
@@ -1246,7 +1247,7 @@ declare namespace JSX {
     srcLang?: FunctionMaybe<Nullable<string>>
   }
 
-  interface VideoHTMLAttributes<T extends EventTarget> extends MediaHTMLAttributes<T> {
+  export interface VideoHTMLAttributes<T extends EventTarget> extends MediaHTMLAttributes<T> {
     height?: FunctionMaybe<Nullable<number | string>>,
     playsInline?: FunctionMaybe<Nullable<boolean>>,
     poster?: FunctionMaybe<Nullable<string>>,
@@ -1255,11 +1256,11 @@ declare namespace JSX {
     disableRemotePlayback?: FunctionMaybe<Nullable<boolean>>
   }
 
-  interface WbrHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
+  export interface WbrHTMLAttributes<T extends EventTarget> extends VoidHTMLAttributes<T> {
 
   }
 
-  interface WebViewHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
+  export interface WebViewHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
     allowFullScreen?: FunctionMaybe<Nullable<boolean>>,
     allowpopups?: FunctionMaybe<Nullable<boolean>>,
     autoFocus?: FunctionMaybe<Nullable<boolean>>,
@@ -1279,7 +1280,7 @@ declare namespace JSX {
     webpreferences?: FunctionMaybe<Nullable<string>>
   }
 
-  interface IntrinsicElementsMap {
+  export interface IntrinsicElementsMap {
     // HTML
     a: HTMLAnchorElement,
     abbr: HTMLElement,
@@ -1451,7 +1452,7 @@ declare namespace JSX {
     use: SVGUseElement
   }
 
-  interface IntrinsicElements {
+  export interface IntrinsicElements {
     // HTML
     a: AnchorHTMLAttributes<HTMLAnchorElement>,
     abbr: HTMLAttributes<HTMLElement>,

--- a/src/methods/create_directive.ts
+++ b/src/methods/create_directive.ts
@@ -4,7 +4,7 @@
 import {DIRECTIVES, SYMBOLS_DIRECTIVES} from '~/constants';
 import resolve from '~/methods/resolve';
 import {context} from '~/oby';
-import type {Child, DirectiveFunction, Directive, DirectiveData, DirectiveOptions, ExtractArray} from '~/types';
+import type {Child, DirectiveFunction, Directive, DirectiveData, DirectiveOptions, ExtractArray, JSX} from '~/types';
 
 /* MAIN */
 

--- a/src/methods/template.ts
+++ b/src/methods/template.ts
@@ -301,7 +301,7 @@ const template = <P = {}> ( fn: (( props: P ) => Child) ): (( props: P ) => () =
 
       const clone = root.cloneNode ( true );
 
-      return wrapElement ( reviver.bind ( undefined, clone, props ) );
+      return wrapElement ( reviver.bind ( undefined, clone as Element, props ) ); // TSC
 
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,8 @@
 
+/* IMPORT */
+
+import type { JSX } from "./jsx/runtime"
+
 /* HELPERS */
 
 declare const ContextWithDefaultSymbol: unique symbol;
@@ -151,4 +155,4 @@ type Truthy<T = unknown> = Exclude<T, 0 | -0 | 0n | -0n | '' | false | null | un
 
 /* EXPORT */
 
-export type {ArrayMaybe, Callback, Child, ChildWithMetadata, Classes, ComponentFunction, ComponentIntrinsicElement, ComponentNode, Component, ComponentsMap, Constructor, ConstructorWith, ContextData, ContextProvider, Context, ContextWithDefault, DirectiveFunction, DirectiveProvider, DirectiveRef, DirectiveRegister, Directive, DirectiveData, DirectiveOptions, Disposer, EffectFunction, EffectOptions, Element, ExtractArray, EventListener, Falsy, ForOptions, FN, FragmentUndefined, FragmentNode, FragmentFragment, FragmentNodes, FragmentFragments, FragmentMixed, Fragment, FunctionMaybe, Indexed, LazyComponent, LazyFetcher, LazyResult, MemoOptions, Observable, ObservableLike, ObservableReadonly, ObservableReadonlyLike, ObservableMaybe, ObservableOptions, PromiseMaybe, Props, Ref, ResourceStaticPending, ResourceStaticRejected, ResourceStaticResolved, ResourceStatic, ResourceFunction, Resource, StoreOptions, Styles, SuspenseCollectorData, SuspenseData, TemplateActionPath, TemplateActionProxy, TemplateActionWithNodes, TemplateActionWithPaths, TemplateVariableProperties, TemplateVariableData, TemplateVariablesMap, Truthy};
+export type {ArrayMaybe, Callback, Child, ChildWithMetadata, Classes, ComponentFunction, ComponentIntrinsicElement, ComponentNode, Component, ComponentsMap, Constructor, ConstructorWith, ContextData, ContextProvider, Context, ContextWithDefault, DirectiveFunction, DirectiveProvider, DirectiveRef, DirectiveRegister, Directive, DirectiveData, DirectiveOptions, Disposer, EffectFunction, EffectOptions, Element, ExtractArray, EventListener, Falsy, ForOptions, FN, FragmentUndefined, FragmentNode, FragmentFragment, FragmentNodes, FragmentFragments, FragmentMixed, Fragment, FunctionMaybe, Indexed, JSX, LazyComponent, LazyFetcher, LazyResult, MemoOptions, Observable, ObservableLike, ObservableReadonly, ObservableReadonlyLike, ObservableMaybe, ObservableOptions, PromiseMaybe, Props, Ref, ResourceStaticPending, ResourceStaticRejected, ResourceStaticResolved, ResourceStatic, ResourceFunction, Resource, StoreOptions, Styles, SuspenseCollectorData, SuspenseData, TemplateActionPath, TemplateActionProxy, TemplateActionWithNodes, TemplateActionWithPaths, TemplateVariableProperties, TemplateVariableData, TemplateVariablesMap, Truthy};


### PR DESCRIPTION
I used this PR as a reference:

https://github.com/vuejs/core/pull/7958/files

I had to update tsex, otherwise couldn't get `paths` working.